### PR TITLE
make rfq proposal accept/decline work again

### DIFF
--- a/includes/class-boopis-rfq-front.php
+++ b/includes/class-boopis-rfq-front.php
@@ -226,7 +226,9 @@ if ( ! class_exists( 'BOOPIS_RFQ_Front' ) ) {
 				// $debug_export = var_export($referer_params, true);
 
 				$order_id = $referer_params['proposal'];
-				$order_key = $referer_params['key'];
+                $order_key = $referer_params['key'];
+
+                $order = wc_get_order($order_id);
 
 				if ( $order->order_key != $order_key ) {
 					throw new Exception( __( 'Your actions are invalid, please try again.', 'boopis-woocommerce-rfq' ) );


### PR DESCRIPTION
Fast fix to make accept/decline of rfqs work again. Didn't check the whole flow, but it seems impossible to me that there is an order object already present without fetching it first. Please review.